### PR TITLE
Made the recorded request object json serializable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 /pkg/
 /spec/reports/
 /tmp/
+.idea
+*.iml

--- a/api_sim.gemspec
+++ b/api_sim.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "sinatra", '~> 1.0'
   spec.add_dependency "nokogiri", '~> 1.6.7'
-  spec.add_dependency "json-schema", '~> 2.5.2'
+  spec.add_dependency "json-schema", '>= 2.5'
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/lib/api_sim/recorded_request.rb
+++ b/lib/api_sim/recorded_request.rb
@@ -9,6 +9,15 @@ module ApiSim
       @path = request_path
     end
 
+    def to_json(options = {})
+      {
+        body: @body,
+        headers: @headers,
+        path: @path,
+        time: @time,
+      }.to_json
+    end
+
     private
     def parse_headers_from(request_env)
       request_env.select do |k, v|


### PR DESCRIPTION
* Recorded request is json serializable so requesting requests returns information about the path, headers, time, and body of the request
* Loosened specificity of json-schema dependency. This was necessary so api-sim could be used in the same project as thoughtbot's json_matchers.