### PR TITLE
Better endpoint matching when requesting requests

### DIFF
--- a/lib/api_sim/built_app.rb
+++ b/lib/api_sim/built_app.rb
@@ -69,8 +69,14 @@ module ApiSim
       ''
     end
 
-    get '/requests/:endpoint_name' do
-      endpoint = self.class.endpoints.select{ |endpoint| endpoint.route == "/#{params[:endpoint_name]}" }.first || halt(404)
+
+    get '/requests/*' do
+      endpoint_name = parse_endpoint_from_request(request) || halt(404)
+
+      endpoint = self.class.endpoints.select do |endpoint|
+        endpoint.route == "/#{endpoint_name}"
+      end.first || halt(404)
+
       endpoint.requests.to_json
     end
 
@@ -145,6 +151,11 @@ module ApiSim
       end
 
       @response_body.empty? ? {} : @response_body
+    end
+
+    def parse_endpoint_from_request(request)
+      path_matcher  = request.path.match(/\/requests\/([\w\/_-]*)/)
+      path_matcher.size == 2 ? path_matcher[1] : nil
     end
   end
 end

--- a/spec/http_sim_spec.rb
+++ b/spec/http_sim_spec.rb
@@ -10,6 +10,7 @@ describe ApiSim do
   before do
     @app = ApiSim.build_app do
       configure_endpoint 'GET', '/endpoint', 'Hi!', 200, {'X-CUSTOM-HEADER' => 'easy as abc'}
+      configure_endpoint 'POST', '/endpoint', {id: 42}.to_json, 200, {'X-CUSTOM-HEADER' => 'easy as abc'}
       configure_endpoint 'POST', '/post_endpoint', {id: 1}.to_json, 201, {'X-CUSTOM-HEADER' => 'now I know my abcs'}
       configure_endpoint 'GET', '/blogs/:blogId', 'Imma Blerg!', 200, {'X-CUSTOM-HEADER' => 'blerg header'}
 
@@ -167,48 +168,110 @@ describe ApiSim do
     expect(response.body).to eq 'You done soap-ed it good'
   end
 
-  it 'can request requests for endpoints' do
-    put '/response/post_endpoint', {body: {id: 42}.to_json, method: 'post'}.to_json, 'CONTENT_TYPE' => 'application/json'
+  context 'requesting the requests for an endpoint' do
+    it 'can request requests for endpoints' do
+      put '/response/post_endpoint', {body: {id: 42}.to_json, method: 'post'}.to_json, 'CONTENT_TYPE' => 'application/json'
 
-    requests_response = get '/requests/post_endpoint'
-    expect(JSON.parse(requests_response.body)).to eq []
+      requests_response = get '/requests/post_endpoint'
+      expect(requests_response).to be_ok
+      expect(JSON.parse(requests_response.body)).to eq []
 
-    post '/post_endpoint', {post: 'body'}.to_json, {'HTTP_ACCEPT' => 'application/json'}
+      post '/post_endpoint', {post: 'body'}.to_json, {'HTTP_ACCEPT' => 'application/json'}
 
-    requests_response = get '/requests/post_endpoint'
-    expect(requests_response).to be_ok
+      requests_response = get '/requests/post_endpoint'
+      expect(requests_response).to be_ok
 
-    requests = JSON.parse(requests_response.body)
-    expect(requests.count).to eq 1
+      requests = JSON.parse(requests_response.body)
+      expect(requests.count).to eq 1
 
-    request = requests.first
-    expect(request['headers']).to include ['ACCEPT', 'application/json']
-    expect(request['body']).to eq({post: 'body'}.to_json)
-    expect(request['path']).to eq('/post_endpoint')
-    expect(Time.parse(request['time'])).to_not be_nil
-  end
+      request = requests.first
+      expect(request['headers']).to include ['ACCEPT', 'application/json']
+      expect(request['body']).to eq({post: 'body'}.to_json)
+      expect(request['path']).to eq('/post_endpoint')
+      expect(Time.parse(request['time'])).to_not be_nil
+    end
 
-  it 'can request requests for endpoints with slashes in the url' do
-    put '/response/namespace/resource', {body: {id: 42}.to_json, method: 'post'}.to_json, 'CONTENT_TYPE' => 'application/json'
+    it 'can request requests for endpoints with slashes in the url' do
+      put '/response/namespace/resource', {body: {id: 42}.to_json, method: 'post'}.to_json, 'CONTENT_TYPE' => 'application/json'
 
-    requests_response = get '/requests/namespace/resource'
-    expect(requests_response).to be_ok
-    expect(JSON.parse(requests_response.body)).to eq []
+      requests_response = get '/requests/namespace/resource'
+      expect(requests_response).to be_ok
+      expect(JSON.parse(requests_response.body)).to eq []
 
-    post '/namespace/resource', {foo: 'bar'}.to_json, {'HTTP_ACCEPT' => 'application/json'}
+      post '/namespace/resource', {foo: 'bar'}.to_json, {'HTTP_ACCEPT' => 'application/json'}
 
-    requests_response = get '/requests/namespace/resource'
-    expect(requests_response).to be_ok
+      requests_response = get '/requests/namespace/resource'
+      expect(requests_response).to be_ok
 
-    requests = JSON.parse(requests_response.body)
-    expect(requests.count).to eq 1
+      requests = JSON.parse(requests_response.body)
+      expect(requests.count).to eq 1
 
-    request = requests.first
-    expect(request['headers']).to include ['ACCEPT', 'application/json']
-    expect(request['body']).to eq({foo: 'bar'}.to_json)
-    expect(request['path']).to eq('/namespace/resource')
-    expect(Time.parse(request['time'])).to_not be_nil
+      request = requests.first
+      expect(request['headers']).to include ['ACCEPT', 'application/json']
+      expect(request['body']).to eq({foo: 'bar'}.to_json)
+      expect(request['path']).to eq('/namespace/resource')
+      expect(Time.parse(request['time'])).to_not be_nil
+    end
 
+    it 'defaults to getting the GET version if multiple endpoints with the same name exist' do
+      put '/response/endpoint', {body: {id: 42}.to_json, method: 'get'}.to_json, 'CONTENT_TYPE' => 'application/json'
+      put '/response/endpoint', {body: {id: 42}.to_json, method: 'post'}.to_json, 'CONTENT_TYPE' => 'application/json'
+
+      requests_response = get '/requests/endpoint'
+      expect(requests_response).to be_ok
+      expect(JSON.parse(requests_response.body)).to eq []
+
+      get '/endpoint', nil, {'HTTP_ACCEPT' => 'application/json'}
+
+      requests_response = get '/requests/endpoint'
+      expect(requests_response).to be_ok
+
+      requests = JSON.parse(requests_response.body)
+      expect(requests.count).to eq 1
+
+      request = requests.first
+      expect(request['headers']).to include ['ACCEPT', 'application/json']
+      expect(request['path']).to eq('/endpoint')
+      expect(Time.parse(request['time'])).to_not be_nil
+    end
+
+    it 'can differentiate on method when requesting requests with the same name and different http verbs' do
+      put '/response/endpoint', {body: {id: 42}.to_json, method: 'get'}.to_json, 'CONTENT_TYPE' => 'application/json'
+      put '/response/endpoint', {body: {id: 42}.to_json, method: 'post'}.to_json, 'CONTENT_TYPE' => 'application/json'
+
+      requests_response = get '/requests/endpoint'
+      expect(requests_response).to be_ok
+      expect(JSON.parse(requests_response.body)).to eq []
+
+      get '/endpoint', nil, {'HTTP_ACCEPT' => 'application/json'}
+
+      requests_response = get '/requests/endpoint'
+      expect(requests_response).to be_ok
+
+      requests = JSON.parse(requests_response.body)
+      expect(requests.count).to eq 1
+
+      requests_response = get '/requests/endpoint?method=POST'
+      expect(requests_response).to be_ok
+
+      requests = JSON.parse(requests_response.body)
+      expect(requests.count).to eq 0
+
+      post '/endpoint', {foo: 'bar'}.to_json, {'HTTP_ACCEPT' => 'application/json'}
+
+      requests_response = get '/requests/endpoint?method=POST'
+      expect(requests_response).to be_ok
+
+      requests = JSON.parse(requests_response.body)
+      expect(requests.count).to eq 1
+
+      request = requests.first
+      expect(request['headers']).to include ['ACCEPT', 'application/json']
+      expect(request['path']).to eq('/endpoint')
+      expect(request['body']).to eq({foo: 'bar'}.to_json)
+      expect(Time.parse(request['time'])).to_not be_nil
+
+    end
   end
 
   private


### PR DESCRIPTION
* allow requested endpoints to have slashes (ex. /namespace/resource)
* allow requested endpoints to specify an http verb, default is get. So `/resources/endpoint_name?method=POST` finds requests to `POST /resources/endpoint_name` whereas `/resource/endpoint_name` finds request to `GET /resources/endpoint_name` if there are multiple endpoints defined with the same name. If only http_verb is defined for a specific endpoint name, the default behavior stays the same.