### PR TITLE
Implemented ability to save query parameters 

### DIFF
--- a/lib/api_sim/matchers/base_matcher.rb
+++ b/lib/api_sim/matchers/base_matcher.rb
@@ -38,7 +38,8 @@ module ApiSim
 
       def record_request(request)
         request.body.rewind
-        requests.push(RecordedRequest.new(body: request.body.read, request_env: request.env, request_path: request.path))
+        requests.push(RecordedRequest.new(body: request.body.read, request_env: request.env, request_path: request.path,
+            query_string: request.params))
       end
 
       def to_s

--- a/lib/api_sim/recorded_request.rb
+++ b/lib/api_sim/recorded_request.rb
@@ -1,12 +1,13 @@
 module ApiSim
   class RecordedRequest
-    attr_reader :time, :headers, :body, :path
+    attr_reader :time, :headers, :body, :path, :query
 
-    def initialize(time: Time.now, body:, request_env:, request_path:)
+    def initialize(time: Time.now, body:, request_env:, request_path:, query_string: )
       @time = time
       @body = body
       @headers = parse_headers_from(request_env)
       @path = request_path
+      @query = query_string
     end
 
     def to_json(options = {})
@@ -15,6 +16,7 @@ module ApiSim
         headers: @headers,
         path: @path,
         time: @time,
+        query: @query
       }.to_json
     end
 

--- a/lib/api_sim/views/requests/index.html.erb
+++ b/lib/api_sim/views/requests/index.html.erb
@@ -8,6 +8,7 @@
         <th>Time</th>
         <th>Body</th>
         <th>Route</th>
+        <th>Query Params</th>
         <th>Headers</th>
     </tr>
     </thead>
@@ -17,6 +18,15 @@
             <th class="header-column"><p><%= request.time %></p></th>
             <td><p><%= h request.body %></p></td>
             <td><p><%= h request.path %></p></td>
+            <td>
+              <ul>
+              <% request.query.each do |name, value| %>
+                <li><%= name %>:
+                <%= value %>
+                </li>
+              <% end %>
+              </ul>
+              </td>
             <td>
               <ul>
               <% request.headers.each do |header, value| %>

--- a/spec/http_sim_spec.rb
+++ b/spec/http_sim_spec.rb
@@ -298,6 +298,21 @@ describe ApiSim do
       requests = get '/requests/GET/blogs/34983943'
       expect(JSON.parse(requests.body).length).to eq 1
     end
+
+    it 'returns query parameters for endpoints' do
+        response = get '/blogs/34983943?q=stuff&fmt=summary&n=1'
+        expect(response).to be_ok
+
+      requests = get '/requests/GET/blogs/34983943'
+      puts requests.body
+      request_bodies = JSON.parse(requests.body)
+      expect(request_bodies.length).to eq 1
+      query = request_bodies.first['query']
+      expect(query).to_not be_nil
+      expect(query['q']).to eq('stuff')
+      expect(query['fmt']).to eq('summary')
+      expect(query['n']).to eq('1')
+    end
   end
 
   private

--- a/spec/ui_spec.rb
+++ b/spec/ui_spec.rb
@@ -240,4 +240,19 @@ describe 'App UI' do
     response = post '/fancy-create', {name: {id: 'not an integer'}}.to_json, 'CONTENT_TYPE' => 'application/json'
     expect(response.status).to eq 498
   end
+
+    it 'can show query strings for the endpoint' do
+      get '/endpoint?foo=bar&test=123'
+
+      visit '/'
+
+      within 'tr', text: '/endpoint' do
+        click_on '1'
+      end
+
+      expect(page).to have_content 'Requests to GET /endpoint'
+      expect(page).to have_content 'foo: bar'
+      expect(page).to have_content 'test: 123'
+    end
+
 end


### PR DESCRIPTION
Implemented ability to save query parameters and view same on requests page

What this does: 
UI now has space to view the query parameters used on the requests to a particular endpoint.

Why:
I had a situation where I wanted to verify the parameters sent to the simulator by my code under test, there currently is no way to do this (that I could tell)

https://github.com/dugancathal/api_sim/issues/17