### PR TITLE
add request schema to fixture config

### DIFF
--- a/lib/api_sim/app_builder.rb
+++ b/lib/api_sim/app_builder.rb
@@ -65,12 +65,14 @@ module ApiSim
       Dir[File.join(dir, "**/*.json.erb")].each do |path|
         endpoint_match = path.match(%r{#{dir}([/\w+\_\-]+)/(GET|POST|PATCH|OPTIONS|HEAD|PUT|DELETE).json})
         config = JSON.parse(File.read(path))
+        request_schema = config['request_schema'].to_json unless config['request_schema'].nil?
         configure_endpoint endpoint_match[2],
           endpoint_match[1],
           config['body'].to_json,
           config['status'],
           config['headers'],
-          config['schema'].to_json
+          config['schema'].to_json,
+          request_schema: request_schema
       end
     end
 

--- a/spec/fixtures/path/to/response/POST.json.erb
+++ b/spec/fixtures/path/to/response/POST.json.erb
@@ -1,0 +1,21 @@
+{
+  "status": 201,
+  "headers": {
+    "content-type": "application/json"
+  },
+  "body": {
+    "id": 1,
+    "name": "Sammy"
+  },
+  "request_schema": {
+    "type": "object",
+    "required": [
+        "name"
+    ],
+    "properties": {
+        "name": {
+            "type": "string"
+        }
+    }
+  }
+}

--- a/spec/http_sim_spec.rb
+++ b/spec/http_sim_spec.rb
@@ -345,6 +345,17 @@ describe ApiSim do
     expect(response_body['id']).to eq 1
   end
 
+  it 'validates json from fixture configuration' do
+    response = make_request_to 'POST', '/path/to/response', {'name': 'mom'}.to_json, 'application/json'
+
+    expect(response).to be_created
+
+    response = make_request_to 'POST', '/path/to/response', {'not_name': 'mom'}.to_json, 'application/json'
+
+    expect(response.status).to eq(498)
+
+  end
+
   it 'records the incoming Content-Type' do
     make_request_to 'POST', '/endpoint', {'hi': 'mom'}.to_json, 'application/foo'
 


### PR DESCRIPTION
see #44 

This adds the ability to set the request schema in the fixture config.